### PR TITLE
AppVeyor should build and package using the Release configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,3 +10,5 @@ build:
   publish_nuget_symbols: true
   parallel: true
   verbosity: minimal
+configuration:
+- Release


### PR DESCRIPTION
Looks like this change has to be done in the `appveyor.yml` file since the default build settings in AppVeyor seem to be ignored if a `appveyor.yml` file is present, even if it doesn't explicitly specify a property's value.

fixes #10